### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/GRIT.iml
+++ b/GRIT.iml
@@ -32,7 +32,7 @@
     <orderEntry type="library" exported="" name="Gradle: jetty-io-9.2.1.v20140609" level="project" />
     <orderEntry type="library" exported="" name="Gradle: activation-1.1" level="project" />
     <orderEntry type="library" exported="" name="Gradle: hamcrest-core-1.3" level="project" />
-    <orderEntry type="library" exported="" scope="RUNTIME" name="Gradle: commons-collections-3.2.1" level="project" />
+    <orderEntry type="library" exported="" scope="RUNTIME" name="Gradle: commons-collections-3.2.2" level="project" />
     <orderEntry type="library" exported="" scope="RUNTIME" name="Gradle: commons-jxpath-1.3" level="project" />
     <orderEntry type="library" exported="" scope="RUNTIME" name="Gradle: commons-beanutils-1.8.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: commons-cli-1.2" level="project" />

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     // config needs older versions of the commons api to run
     compile group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
     runtime group: 'commons-collections', name: 'commons-collections',
-            version: '3.2.1'
+            version: '3.2.2'
     runtime group: 'commons-lang', name: 'commons-lang', version: '2.6'
     runtime group: 'commons-jxpath', name: 'commons-jxpath', version: '1.3'
     runtime group: 'commons-beanutils', name: 'commons-beanutils', version: '1.8.0'


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
